### PR TITLE
Allow usage of non-UNIX line endings

### DIFF
--- a/src/main/resources/io/netty/checkstyle.xml
+++ b/src/main/resources/io/netty/checkstyle.xml
@@ -42,11 +42,6 @@
     <property name="ignoreCase" value="true"/>
     <property name="message" value="unmaintainable Javadoc tags: @author, @version, or (non-Javadoc)"/>
   </module>
-  <!-- Force UNIX line separator -->
-  <module name="RegexpMultiline">
-    <property name="format" value="\r"/>
-    <property name="message" value="non-Unix line separator"/>
-  </module>
   <!-- Trailing whitespace -->
   <module name="RegexpSingleline">
     <property name="format" value="\s+$"/>


### PR DESCRIPTION
This theoretically allows Netty to be built with the default
Git configuration on Windows.

There is no reason that I am aware of to prevent this, so please
enlighten me if/why this was originally blocked in the first place :)

Signed-off-by: Cruz Julian Bishop cruzjbishop@gmail.com
