### PR TITLE
Upgrade checkstyle dependency to work with java 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>com.puppycrawl.tools</groupId>
       <artifactId>checkstyle</artifactId>
-      <version>6.16.1</version>
+      <version>7.3</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Motivation:

We need to upgrade the checkstyle dependency to also work with java 9.

Modifications:

Upgrade to version 7.3.

Result:

Be able to use with java 9.