### PR TITLE
Update checkstyle to 8.29

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>com.puppycrawl.tools</groupId>
       <artifactId>checkstyle</artifactId>
-      <version>8.18</version>
+      <version>8.29</version>
     </dependency>
 
     <dependency>

--- a/src/main/resources/io/netty/checkstyle.xml
+++ b/src/main/resources/io/netty/checkstyle.xml
@@ -67,10 +67,12 @@
     <property name="message" value="an empty line after a short line that ends with '{'"/>
   </module>
 
+  <module name="LineLength">
+    <property name="max" value="120"/>
+    <property name="fileExtensions" value="java"/>
+  </module>
+
   <module name="TreeWalker">
-    <module name="LineLength">
-      <property name="max" value="120"/>
-    </module>
     <module name="WhitespaceAfter"/>
     <module name="WhitespaceAround">
       <property name="tokens" value="ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, BXOR_ASSIGN, DIV, DIV_ASSIGN, EQUAL, GE, GT, LAND, LCURLY, LE, LITERAL_ASSERT, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF, LITERAL_RETURN, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS, MINUS_ASSIGN, MOD, MOD_ASSIGN, NOT_EQUAL, PLUS, PLUS_ASSIGN, RCURLY, SL, SLIST, SL_ASSIGN, SR, SR_ASSIGN, STAR, STAR_ASSIGN, TYPE_EXTENSION_AND"/>


### PR DESCRIPTION
Motivation:

We need to upgrade our checkstyle version to 8.29 to fix a security vulnerability

Modifications:

Update version of checkstyle and make config compatible with latest version

Result:

Other projects can update their dependencies to use the new checkstyle version while also depending on netty-build