### PR TITLE
Upgrade checkstyle to 10.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
       <dependency>
         <groupId>com.puppycrawl.tools</groupId>
         <artifactId>checkstyle</artifactId>
-        <version>8.29</version>
+        <version>10.6.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Checkstyle 10.6.0 is available and we should upgrade to it.